### PR TITLE
chore: Revert "chore: bump @rollup/plugin-typescript from 12.1.2 to 12.1.3 (…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@eslint/js": "^9.29.0",
         "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-strip": "^3.0.4",
-        "@rollup/plugin-typescript": "^12.1.3",
+        "@rollup/plugin-typescript": "^12.1.2",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/exec": "^7.1.0",
@@ -1850,9 +1850,9 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.3.tgz",
-      "integrity": "sha512-gAx0AYwkyjqOw4JrZV34N/abvAobLhczyLkZ7FVL2UXPrO4zv8oqTfYT3DLBRan1EXasp4SUuEJXqPTk0gnJzw==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.2.tgz",
+      "integrity": "sha512-cdtSp154H5sv637uMr1a8OTWB0L1SWDSm1rDGiyfcGcvQ6cuTs4MDk2BVEBGysUWago4OJN4EQZqOTl/QY3Jgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@eslint/js": "^9.29.0",
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-strip": "^3.0.4",
-    "@rollup/plugin-typescript": "^12.1.3",
+    "@rollup/plugin-typescript": "^12.1.2",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^7.1.0",


### PR DESCRIPTION
…#11)"

This reverts commit d06c99f5fc2c90ecf1703df0f19d297fba054825.