### PR TITLE
fix: resolve untracked-file paths correctly when format-uncommitted is run from a subdirectory

### DIFF
--- a/src/functions/diff.mts
+++ b/src/functions/diff.mts
@@ -141,7 +141,15 @@ const cmdResultToFiles = async ({
     ]
       .filter((s) => s !== '')
       .join(' '),
-    { silent: options?.silent ?? false },
+    {
+      silent: options?.silent ?? false,
+      // Run git from the repository root so that `git ls-files` (which
+      // defaults to cwd-relative paths) and other commands return paths
+      // relative to the repository root, matching the `path.join(gitRoot, …)`
+      // computation below regardless of the caller's current working
+      // directory.
+      cwd: gitRoot,
+    },
   );
 
   if (Result.isErr(result)) {

--- a/src/functions/diff.test.mts
+++ b/src/functions/diff.test.mts
@@ -143,6 +143,48 @@ describe('diff', () => {
       }
     });
 
+    test('should resolve paths correctly when invoked from a subdirectory', async () => {
+      const { repoPath, cleanup } = await createTempRepo();
+
+      try {
+        // Create a subdirectory and an untracked file inside it
+        const subDir = path.join(repoPath, 'sub');
+
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        await fs.mkdir(subDir);
+
+        const testFileName =
+          `test-untracked-${crypto.randomUUID()}.tmp` as const;
+
+        const testFilePath = path.join(subDir, testFileName);
+
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        await fs.writeFile(testFilePath, 'test content');
+
+        // Invoke getUntrackedFiles from the subdirectory (not from repo root).
+        // Without the cwd fix, git ls-files would return paths relative to
+        // the subdirectory, which would then be incorrectly joined with
+        // gitRoot.
+        const originalCwd = process.cwd();
+
+        process.chdir(subDir);
+
+        try {
+          const result = await getUntrackedFiles({ silent: true });
+
+          assert.isTrue(Result.isOk(result));
+
+          if (Result.isOk(result)) {
+            expect(result.value).toContain(testFilePath);
+          }
+        } finally {
+          process.chdir(originalCwd);
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+
     test('should detect modified existing files', async () => {
       const { repoPath, cleanup, execInRepo } = await createTempRepo();
 


### PR DESCRIPTION
## Summary

\`cmdResultToFiles\` in \`src/functions/diff.mts\` runs git commands and joins each output line with \`gitRoot\` to produce absolute paths:

\`\`\`ts
.map((relativePath) => path.join(gitRoot, relativePath));
\`\`\`

This assumes the git command emits paths relative to the repository root. \`git diff --name-only\` already does so even from a subdirectory, but \`git ls-files --others --exclude-standard\` defaults to **cwd-relative** paths. So when \`format-uncommitted\` (or any \`getUntrackedFiles\` consumer) is invoked from a subdir, untracked files were either silently skipped (the wrongly-resolved absolute path didn't exist) or — if the same relative path happened to exist at gitRoot — quietly resolved to the wrong file.

The fix runs git via \`{ cwd: gitRoot }\`, which makes every git command behave as if it was invoked from gitRoot. After this change \`getUntrackedFiles\` returns the correct absolute paths regardless of where the caller is invoked from, which removes the last footgun for the new \`--cwd\` option introduced in 10.1.0.

## Test plan

- [x] Added \`should resolve paths correctly when invoked from a subdirectory\` to \`diff.test.mts\` — creates an untracked file under a subdir, \`process.chdir\`'s into the subdir, then asserts \`getUntrackedFiles\` returns the original absolute path
- [x] All 96 tests pass (\`pnpm run test\`)
- [x] Lint, type-check, build, codemod:full, doc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)