### PR TITLE
refactor: clarify doc:embed fence regex docs and derive global regex flags

### DIFF
--- a/scripts/cmd/embed-examples.mts
+++ b/scripts/cmd/embed-examples.mts
@@ -11,8 +11,8 @@ const codeBlockEnd = '```';
 /**
  * Matches the start of an opening code fence whose language tag is exactly
  * `ts`, `tsx`, or `js`. The `(?=\s|$)` lookahead requires the tag to be followed
- * by whitespace or end-of-line, so fences such as ```jsx, ```typescript, or
- * ```ts-ignore are not matched. Only the fence prefix (backticks + tag) is
+ * by whitespace or end-of-line, so tags like `jsx`, `typescript`, or
+ * `ts-ignore` are not matched. Only the fence prefix (backticks + tag) is
  * matched; any trailing info string is not part of the match.
  */
 const codeBlockStartRegex = /^```(?:tsx|ts|js)(?=\s|$)/mu;

--- a/scripts/cmd/embed-examples.mts
+++ b/scripts/cmd/embed-examples.mts
@@ -9,15 +9,22 @@ import { extractSampleCode } from './embed-examples-utils.mjs';
 const codeBlockEnd = '```';
 
 /**
- * Matches the opening line of a fenced code block whose language tag is exactly
- * `ts`, `tsx`, or `js` (optionally followed by an info string). The `(?=\s|$)`
- * lookahead requires the tag to end at whitespace or end-of-line, so fences such
- * as ```jsx, ```typescript, or ```ts-ignore are not matched.
+ * Matches the start of an opening code fence whose language tag is exactly
+ * `ts`, `tsx`, or `js`. The `(?=\s|$)` lookahead requires the tag to be followed
+ * by whitespace or end-of-line, so fences such as ```jsx, ```typescript, or
+ * ```ts-ignore are not matched. Only the fence prefix (backticks + tag) is
+ * captured; any trailing info string is not part of the match.
  */
 const codeBlockStartRegex = /^```(?:tsx|ts|js)(?=\s|$)/mu;
 
-/** Global counterpart of {@link codeBlockStartRegex} for counting all fences. */
-const codeBlockStartRegexGlobal = new RegExp(codeBlockStartRegex, 'gmu');
+/**
+ * Global counterpart of {@link codeBlockStartRegex} for counting all fences. The
+ * flags are derived from `codeBlockStartRegex` (plus `g`) so the two cannot drift.
+ */
+const codeBlockStartRegexGlobal = new RegExp(
+  codeBlockStartRegex,
+  `${codeBlockStartRegex.flags}g`,
+);
 
 /**
  * Each entry maps to a code block (```tsx / ```ts / ```js) in the target

--- a/scripts/cmd/embed-examples.mts
+++ b/scripts/cmd/embed-examples.mts
@@ -13,7 +13,7 @@ const codeBlockEnd = '```';
  * `ts`, `tsx`, or `js`. The `(?=\s|$)` lookahead requires the tag to be followed
  * by whitespace or end-of-line, so fences such as ```jsx, ```typescript, or
  * ```ts-ignore are not matched. Only the fence prefix (backticks + tag) is
- * captured; any trailing info string is not part of the match.
+ * matched; any trailing info string is not part of the match.
  */
 const codeBlockStartRegex = /^```(?:tsx|ts|js)(?=\s|$)/mu;
 
@@ -23,7 +23,7 @@ const codeBlockStartRegex = /^```(?:tsx|ts|js)(?=\s|$)/mu;
  */
 const codeBlockStartRegexGlobal = new RegExp(
   codeBlockStartRegex,
-  `${codeBlockStartRegex.flags}g`,
+  `${codeBlockStartRegex.flags.replace('g', '')}g`,
 );
 
 /**


### PR DESCRIPTION
Follow-up addressing the Copilot review comments on the `doc:embed` scripts.

- Reword the JSDoc so it describes the actual match: only the fence prefix (backticks + language tag) is captured, and trailing info strings are not part of the match. Previously it implied the whole opening line / info string was matched.
- Derive `codeBlockStartRegexGlobal`'s flags from `codeBlockStartRegex` (plus `g`) instead of hard-coding `'gmu'`, so the global counterpart cannot silently drift from the base pattern.

Verified: `tsc`, `eslint`, and `prettier` pass, and `doc:embed` produces no change to the embedded markdown (behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
