### PR TITLE
chore: sync Node.js version matrix with ts-data-forge

### DIFF
--- a/.github/workflows/node-version-compatibility.yml
+++ b/.github/workflows/node-version-compatibility.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22.18.0', '22.22.2', '24.14.1', '25.9.0']
+        node-version: ['22.22.2', '24.17.0', '26.3.1']
 
     steps:
       - name: Checkout

--- a/github/rulesets/main.json
+++ b/github/rulesets/main.json
@@ -78,19 +78,15 @@
             "integration_id": 15368
           },
           {
-            "context": "test-node-versions (22.18.0)",
-            "integration_id": 15368
-          },
-          {
             "context": "test-node-versions (22.22.2)",
             "integration_id": 15368
           },
           {
-            "context": "test-node-versions (24.14.1)",
+            "context": "test-node-versions (24.17.0)",
             "integration_id": 15368
           },
           {
-            "context": "test-node-versions (25.9.0)",
+            "context": "test-node-versions (26.3.1)",
             "integration_id": 15368
           }
         ]

--- a/package.json
+++ b/package.json
@@ -141,10 +141,10 @@
   },
   "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "engines": {
-    "node": ">=22.18.0",
+    "node": ">=22.22.2",
     "pnpm": ">=8.0.0"
   },
   "volta": {
-    "node": "25.9.0"
+    "node": "26.3.1"
   }
 }


### PR DESCRIPTION
## Summary
Bump the Node.js compatibility matrix, `engines.node` floor, and volta pin from the stale `['22.18.0', '22.22.2', '24.14.1', '25.9.0']` set to `['22.22.2', '24.17.0', '26.3.1']`, matching ts-data-forge's current settings (the source of truth for this repo family). Also update the required status check contexts in `github/rulesets/main.json` to the new `test-node-versions` job names, since GitHub's required-status-checks list must match the actual job names emitted by the workflow matrix.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds under local Node 22.22.2
- [x] `pnpm run build` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZXTnGfYFgqbbEgYxRycrG)_